### PR TITLE
Fix Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ Capa is an open-source tool developed by Mandiant (formerly FireEye) that detect
 To deploy this worker, add the following service configuration to your OpenRelik `docker-compose.yml` file:
 
 ```yaml
-openrelik-worker-openrelik-worker-capa:
-    container_name: openrelik-worker-openrelik-worker-capa
-    image: ghcr.io/openrelik/openrelik-worker-openrelik-worker-capa:latest
+openrelik-worker-capa:
+    container_name: openrelik-worker-capa
+    image: ghcr.io/openrelik/openrelik-worker-capa:latest
     restart: always
     environment:
       - REDIS_URL=redis://openrelik-redis:6379
       - OPENRELIK_PYDEBUG=0 # Set to 1 for debugpy remote debugging
     volumes:
       - ./data:/usr/share/openrelik/data
-    command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-openrelik-worker-capa"
+    command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-capa"
 ```
 
 ## Test


### PR DESCRIPTION
Hey, hope it is ok that I didn't make an issue and just directly made a PR

Documentation refers to `openrelik-worker-openrelik-worker-capa`, when the actual image built is `openrelik-worker-capa`. I suspect this is a typo.

My initial scan of the source code says that the celery queue is also called `openrelik-worker-capa`, but I might be wrong, so please double check.